### PR TITLE
Master upstream

### DIFF
--- a/src/Node/CommentedIncludeNode.php
+++ b/src/Node/CommentedIncludeNode.php
@@ -28,7 +28,7 @@ class CommentedIncludeNode extends IncludeNode implements NodeOutputInterface
 		$compiler->addDebugInfo($this);
 
 		$compiler
-			->raw("echo '<!-- Begin output of " )
+			->raw("yield '<!-- Begin output of " )
 			->subcompile($this->getNode('expr'))
 			->raw(" -->';\n\n")
 		;
@@ -60,7 +60,7 @@ class CommentedIncludeNode extends IncludeNode implements NodeOutputInterface
 		}
 
 		$compiler
-			->raw("echo '<!-- / End output of " )
+			->raw("yield '<!-- / End output of " )
 			->subcompile($this->getNode('expr'))
 			->raw(" -->';\n\n")
 		;

--- a/src/Node/CommentedIncludeNode.php
+++ b/src/Node/CommentedIncludeNode.php
@@ -23,6 +23,7 @@ class CommentedIncludeNode extends IncludeNode implements NodeOutputInterface
 	/**
 	 * @param \Twig_Compiler $compiler
 	 */
+	#[YieldReady]
 	public function compile(Compiler $compiler): void
 	{
 		$compiler->addDebugInfo($this);


### PR DESCRIPTION
Relates to issue: #2 

Deprecation warning:

> PHP Deprecated: Since twig/twig 3.9: Twig node "Djboris88\Twig\Node\CommentedIncludeNode" is not marked as ready for using "yield" instead of "echo"; please make it ready and then flag it with the #[YieldReady] attribute. in /var/www/html/vendor/symfony/deprecation-contracts/function.php on line 25
> PHP Deprecated: Since twig/twig 3.9: Twig node "Djboris88\Twig\Node\CommentedIncludeNode" is not marked as ready for using "yield" instead of "echo"; please make it ready and then flag it with the #[YieldReady] attribute. in /var/www/html/vendor/symfony/deprecation-contracts/function.php on line 25

Changes: 
1. `echo` replaced with `yield` to resolve the deprecation warning. 
2. YieldReady attribute added to the class as recommended here: https://github.com/twigphp/Twig/blob/3.x/CHANGELOG#L109

PHP Attributes are a PHP 8 feature, I'm not sure how that factors in to this PR. I know you use WordPress Timber, the requirements for that are PHP 7.4 >=. 

> Timber 2.0 requires you to use a PHP version >= 7.4. 